### PR TITLE
Fixed the per-element opacity on Surface plots

### DIFF
--- a/src/lib/gl_format_color.js
+++ b/src/lib/gl_format_color.js
@@ -91,7 +91,7 @@ function parseColorScale(cont, alpha) {
         var rgb = color.toRgb();
         return {
             index: index,
-            rgb: [rgb.r, rgb.g, rgb.b, alpha]
+            rgb: [rgb.r, rgb.g, rgb.b, rgb.a]
         };
     });
 }


### PR DESCRIPTION
This works only if the global opacity is also specified and <1. To blend different surfaces, an opacity of 0.99 works great. @nicolaskruchten
